### PR TITLE
Update for Singularity 2.4 and above (image.export)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
   - docker
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: python
 services:
   - docker

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Clair instance, or that only a trusted Clair instance can retrieve images from t
 To use clair-singularity you will need a _Linux_ host with:
 
   * Python 2.7 or greater installed
-  * Singularity 2.4+ installed (tested with 2.4.5) and the singularity executable in your `PATH`
+  * Singularity 2.4+ installed (tested with 2.4.6) and the singularity executable in your `PATH`
   * A Clair instance running somewhere, that is able to access the machine you will run 
   clair-singularity on. It's easiest to accomplish this using docker to run a local Clair instance as below.
   
@@ -58,11 +58,11 @@ https://github.com/arminc/clair-local-scan
 To startup a Clair instance locally using these instances:
 
 ```bash
-docker run -d --name db arminc/clair-db:20187-08-21
-docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.0
+docker run -d --name db arminc/clair-db:2018-04-01
+docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.1
 ```
 
-*Replace the clair-db:2017-08-21 image tag with a later date for newer vulnerabilities*
+*Replace the clair-db:2018-04-01 image tag with a later date for newer vulnerabilities*
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Clair instance, or that only a trusted Clair instance can retrieve images from t
 To use clair-singularity you will need a _Linux_ host with:
 
   * Python 2.7 or greater installed
-  * Singularity installed (tested with 2.3.1) and the singularity executable in your `PATH`
+  * Singularity 2.4+ installed (tested with 2.4.5) and the singularity executable in your `PATH`
   * A Clair instance running somewhere, that is able to access the machine you will run 
   clair-singularity on. It's easiest to accomplish this using docker to run a local Clair instance as below.
   

--- a/build_scripts/docker_local_tests.sh
+++ b/build_scripts/docker_local_tests.sh
@@ -3,12 +3,21 @@
 set -e
 set -u
 
-docker pull arminc/clair-db:2017-08-21
-docker run -d --name db arminc/clair-db:2017-08-21
+docker stop clair-db clair || true
+docker rm clair-db clair || true
 
-docker pull arminc/clair-local-scan:v2.0.0
-docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.0
+docker pull arminc/clair-db:2018-04-01
+docker run -d --name clair-db arminc/clair-db:2018-04-01
 
-docker rm clair_singularity
-docker build -t clair_singularity .
-docker run --privileged --name clair-singularity --link clair:clair clair_singularity pytest tests/ --cov clair_singularity --cov-report term-missing
+sleep 5
+
+docker pull arminc/clair-local-scan:v2.0.1
+docker run -p 6060:6060 --link clair-db:postgres -d --name clair arminc/clair-local-scan:v2.0.1
+
+docker rm clair-singularity || true
+docker build -t clair-singularity .
+docker run --privileged --name clair-singularity --link clair clair-singularity pytest tests/ --cov clair_singularity --cov-report term-missing
+
+docker stop clair-db clair clair-singularity || true
+docker rm clair-db clair clair-singularity || true
+

--- a/build_scripts/travis_tests.sh
+++ b/build_scripts/travis_tests.sh
@@ -11,10 +11,11 @@ pytest tests/ -v -m "not needs_clair" --cov clair_singularity --cov-report term-
 
 if [[ $TRAVIS_PYTHON_VERSION == "3.5"* ]]; then
     echo "Python 3.5 - running docker tests with Clair"
-    docker pull arminc/clair-db:2017-08-21
+    docker pull arminc/clair-db:2018-04-01
     docker run -d --name db arminc/clair-db:2017-08-21
-    docker pull arminc/clair-local-scan:v2.0.0
-    docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.0
+    sleep 5
+    docker pull arminc/clair-local-scan:v2.0.1
+    docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.1
     docker ps
     docker build -t clair_singularity .
 

--- a/build_scripts/travis_tests.sh
+++ b/build_scripts/travis_tests.sh
@@ -12,7 +12,7 @@ pytest tests/ -v -m "not needs_clair" --cov clair_singularity --cov-report term-
 if [[ $TRAVIS_PYTHON_VERSION == "3.5"* ]]; then
     echo "Python 3.5 - running docker tests with Clair"
     docker pull arminc/clair-db:2018-04-01
-    docker run -d --name db arminc/clair-db:2017-08-21
+    docker run -d --name db arminc/clair-db:2018-04-01
     sleep 5
     docker pull arminc/clair-local-scan:v2.0.1
     docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:v2.0.1

--- a/clair_singularity/image.py
+++ b/clair_singularity/image.py
@@ -24,7 +24,7 @@ def image_to_tgz(image, quiet):
     tar_file = path.join(temp_dir, path.basename(image) + '.tar')
     tar_gz_file = tar_file + '.gz'
 
-    cmd = ['singularity', 'export', '-f', tar_file, image]
+    cmd = ['singularity', 'image.export', '-f', tar_file, image]
 
     if not quiet:
         sys.stderr.write("Exporting image to .tar\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,16 +27,16 @@ def test_full_json(runner, testimage):
                             'http://clair:6060', testimage])
     output = json.loads(result.output)
 
-    # Using the shub://396 image and the 2017-08-21 clair db...
+    # Using the shub hello-world image and the 2017-08-21 clair db...
     # There are 62 features in the container scan, and 14 have vulnerabilities
     assert 'Layer' in output
     assert 'Features' in output['Layer']
-    assert len(output['Layer']['Features']) == 62
+    assert len(output['Layer']['Features']) == 126
     features_with_vuln = 0
     for feature in output['Layer']['Features']:
         if 'Vulnerabilities' in feature:
             features_with_vuln = features_with_vuln + 1
-    assert features_with_vuln == 14
+    assert features_with_vuln == 30
 
 
 @pytest.mark.needs_clair
@@ -44,5 +44,5 @@ def test_full_text(runner, testimage):
     result = runner.invoke(cli, ['--quiet', '--bind-ip', MY_IP, '--bind-port', '8082', '--clair-uri',
                                  'http://clair:6060', testimage])
     # Check we do have some CVEs we expect reported here
-    assert 'bash - 4.3-14ubuntu1.1' in result.output
-    assert 'CVE-2016-9401' in result.output
+    assert 'ssl' in result.output
+    assert 'CVE' in result.output

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -16,9 +16,9 @@ def testimage(tmpdir):
     cwd = os.getcwd()
     os.chdir(tmpdir.strpath)
     # This pulls a singularity hello world image
-    subprocess.check_output(['singularity', 'pull', 'shub://396'])
+    subprocess.check_output(['singularity', 'pull', 'shub://singularityhub/hello-world:latest'])
     os.chdir(cwd)
-    return os.path.join(tmpdir.strpath, 'vsoch-singularity-hello-world-master.img')
+    return os.path.join(tmpdir.strpath, 'singularityhub-hello-world-master-latest.simg')
 
 
 def test_check_image(testimage):
@@ -54,10 +54,9 @@ def test_http_server(testimage, tmpdir):
         err_and_exit("HTTP server did not become ready", 1)
 
 
-    r = requests.get('http://127.0.0.1:8088/vsoch-singularity-hello-world-master.img',
-                     proxies={'http://127.0.0.1': ''}, stream=True)
+    r = requests.get('http://127.0.0.1:8088/singularityhub-hello-world-master-latest.simg', stream=True)
 
-    tmpfile = os.path.join(tmpdir.strpath, 'downloaded.img')
+    tmpfile = os.path.join(tmpdir.strpath, 'downloaded.simg')
     # Check the file is good
     with open(tmpfile, 'wb') as fd:
         for block in r.iter_content(1024):
@@ -67,4 +66,4 @@ def test_http_server(testimage, tmpdir):
 
     assert r.status_code == requests.codes.ok
     assert sha256(tmpfile) == \
-        '4dba283867ee8bd6178cb6f58778bf8b59e14833468fab58c4e52d9eeae7759f'
+        '604551697a76f8855be73b4dbf1fd49097f1087de7d5826bc0c6f2bfa81ce4fe'


### PR DESCRIPTION
Use `image.export` when calling Singularity, and fix tests for current state of test image and clair-db.

Closes #5 